### PR TITLE
Reference/Syntax Error (issue no. #36)

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,9 +1,15 @@
 let scores = [0, 0]; // [highScore, currentScore]
-let scoresFromLocalStorage = JSON.parse(localStorage.getItem("scores"));
 let highScoreEl = document.getElementById("highScore");
 let highScore = 0;
 let scoreAfter = 0;
 let displayMove = "";
+let scoresFromLocalStorage;
+if(localStorage.getItem("scores") == "0,0") {
+  scoresFromLocalStorage = null;
+} else {
+  scoresFromLocalStorage = JSON.parse(localStorage.getItem("scores"));
+}
+
 if (scoresFromLocalStorage) {
   highScore = parseInt(scoresFromLocalStorage[0]);
   scoreAfter = parseInt(scoresFromLocalStorage[1]);
@@ -144,7 +150,8 @@ function resetGame() {
   resetButton.onclick = () => {
     highScore = 0;
     scoreAfter = 0;
-    scores = [0, 0];
+    scores[0] = highScore;
+    scores[1] = scoreAfter;
     localStorage.setItem("scores", JSON.stringify(scores));
     highScoreEl.textContent = "High score: " + highScore;
     document.getElementById("player-score").innerText = scoreAfter;


### PR DESCRIPTION
## https://github.com/uday03meh/RockPaperScissors/pull/37#issuecomment-1279951256

## Error Faced
<img src="https://user-images.githubusercontent.com/59679281/196033043-bff12760-ddcc-416a-a973-cbc90a8c7e7c.png" />

## Reason behind error statement: 
- It's not in the code but after the 'reset' button was added to the main branch, inside the resetGame() function, "0,0" was set into local storage instead of "[0,0]". 
- So if at any point you reset the game and directly refresh the page, "0,0" remains in local storage forever. and JSON.parse() finds "," inside "0,0" as a "non-whitespace" character and throws error immediately.

## Rectification:

- I've added one checkpoint to eliminate the browser from considering "0,0" and 
- instead, it considers "0,0" as _null_ so the program runs smooth. 

I deployed the website from my Repo. I've covered almost all the test cases.