### PR TITLE
Added the functionality to reset score to zero after reloading 

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link href="style.css" rel="stylesheet" type="text/css" />
 </head>
 
-  <body>
+  <body onload="setZero()" >
     <div class="wrapper">
       <div class="wrapper-child">
         <h1 id = "heading">Rock Paper Scissors</h1>

--- a/script.js
+++ b/script.js
@@ -23,6 +23,11 @@ function getComputerChoice(choices) {
 }
 // console.log(getComputerChoice(choices));
 
+// To set score to zero on loading
+function setZero() {
+  document.getElementById("player-score").innerText = "0";
+}
+
 function getResult(playerChoice, computerChoice) {
   scoreBefore = document.getElementById("player-score").innerText;
   if (playerChoice == "Rock") {


### PR DESCRIPTION
Added the functionality to reset score to zero after reloading. 

## PR Title
The purpose of this Pull Request is to fix #42 

## Description
This fix will ensure that whenever a user clicks on reload his score will reset to zero.
## How you solved
To Solve this problem I use onload event listener and JavaScript function. Whenever a person click on reload, the onload event will be fired and the score will be set to zero.

### Screenshots




https://user-images.githubusercontent.com/78460491/196605197-d1a90887-bda7-47e3-8366-bae77a890981.mp4


  

##  Checklist
- [x] I have Made this contribution as per the CONTRIBUTING guide in this repo.
- [x] I have tested in local Environment.
- [x] I have made the fix as per issue converstaion.

